### PR TITLE
Loosen validations not required by the DMN standard

### DIFF
--- a/model-evaluator/src/tests/mod.rs
+++ b/model-evaluator/src/tests/mod.rs
@@ -11,6 +11,7 @@ use walkdir::WalkDir;
 
 mod compatibility;
 mod input_data;
+mod simulation;
 mod various;
 
 macro_rules! from_examples {

--- a/model-evaluator/src/tests/simulation/mod.rs
+++ b/model-evaluator/src/tests/simulation/mod.rs
@@ -1,0 +1,71 @@
+mod v13 {
+  use crate::tests::*;
+  const SIMULATION_V13: &str = include_str!("simulation_v13.dmn");
+  model_evaluator!(SIMULATION_V13);
+  const MODEL_NAMESPACE: &str = "https://camunda.org/schema/1.0/dmn";
+  const MODEL_NAME: &str = "Dinner Decisions";
+
+  #[test]
+  fn _0001() {
+    let ctx = context(r#"{ Season: "Spring", "Number of Guests": 2, "Guests with children?": true }"#);
+    let invocable = "Dish";
+    let expected = r#""Dry Aged Gourmet Steak""#;
+    assert_decision(&MODEL_EVALUATOR, MODEL_NAMESPACE, MODEL_NAME, invocable, &ctx, expected);
+  }
+
+  #[test]
+  fn _0002() {
+    let ctx = context(r#"{ Season: "Spring", "Number of Guests": 2, "Guests with children?": true }"#);
+    let invocable = "Beverages";
+    let expected = r#"["Pinot Noir", "Apple Juice"]"#;
+    assert_decision(&MODEL_EVALUATOR, MODEL_NAMESPACE, MODEL_NAME, invocable, &ctx, expected);
+  }
+}
+
+mod v14 {
+  use crate::tests::*;
+  const SIMULATION_V14: &str = include_str!("simulation_v14.dmn");
+  model_evaluator!(SIMULATION_V14);
+  const MODEL_NAMESPACE: &str = "https://camunda.org/schema/1.0/dmn";
+  const MODEL_NAME: &str = "Dinner Decisions";
+
+  #[test]
+  fn _0001() {
+    let ctx = context(r#"{ Season: "Spring", "Number of Guests": 2, "Guests with children?": true }"#);
+    let invocable = "Dish";
+    let expected = r#""Dry Aged Gourmet Steak""#;
+    assert_decision(&MODEL_EVALUATOR, MODEL_NAMESPACE, MODEL_NAME, invocable, &ctx, expected);
+  }
+
+  #[test]
+  fn _0002() {
+    let ctx = context(r#"{ Season: "Spring", "Number of Guests": 2, "Guests with children?": true }"#);
+    let invocable = "Beverages";
+    let expected = r#"["Pinot Noir", "Apple Juice"]"#;
+    assert_decision(&MODEL_EVALUATOR, MODEL_NAMESPACE, MODEL_NAME, invocable, &ctx, expected);
+  }
+}
+
+mod v15 {
+  use crate::tests::*;
+  const SIMULATION_V15: &str = include_str!("simulation_v15.dmn");
+  model_evaluator!(SIMULATION_V15);
+  const MODEL_NAMESPACE: &str = "https://camunda.org/schema/1.0/dmn";
+  const MODEL_NAME: &str = "Dinner Decisions";
+
+  #[test]
+  fn _0001() {
+    let ctx = context(r#"{ Season: "Spring", "Number of Guests": 2, "Guests with children?": true }"#);
+    let invocable = "Dish";
+    let expected = r#""Dry Aged Gourmet Steak""#;
+    assert_decision(&MODEL_EVALUATOR, MODEL_NAMESPACE, MODEL_NAME, invocable, &ctx, expected);
+  }
+
+  #[test]
+  fn _0002() {
+    let ctx = context(r#"{ Season: "Spring", "Number of Guests": 2, "Guests with children?": true }"#);
+    let invocable = "Beverages";
+    let expected = r#"["Pinot Noir", "Apple Juice"]"#;
+    assert_decision(&MODEL_EVALUATOR, MODEL_NAMESPACE, MODEL_NAME, invocable, &ctx, expected);
+  }
+}

--- a/model-evaluator/src/tests/simulation/simulation_v13.dmn
+++ b/model-evaluator/src/tests/simulation/simulation_v13.dmn
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="dinnerDecisions"
+             name="Dinner Decisions"
+             namespace="https://camunda.org/schema/1.0/dmn"
+             exporter="Camunda Modeler"
+             exporterVersion="4.0.0">
+    <decision id="beverages" name="Beverages">
+
+        <informationRequirement id="InformationRequirement_1xvojck">
+            <requiredInput href="#InputData_0pgvdj9"/>
+        </informationRequirement>
+        <informationRequirement id="InformationRequirement_083jsex">
+            <requiredDecision href="#dish"/>
+        </informationRequirement>
+
+        <decisionTable id="DecisionTable_07q05jb" hitPolicy="COLLECT">
+            <input id="InputClause_1acmlkd" label="Dish">
+                <inputExpression id="LiteralExpression_0bqgrlg" typeRef="string">
+                    <text>Dish</text>
+                </inputExpression>
+            </input>
+            <input id="InputClause_0bo3uen" label="Guests with children">
+                <inputExpression id="LiteralExpression_0d6l79o" typeRef="boolean">
+                    <text>Guests with children?</text>
+                </inputExpression>
+            </input>
+            <output id="OuputClause_99999" label="Beverages" name="beverages" typeRef="string"/>
+            <rule id="row-506282952-7">
+                <description>Tough Stuff</description>
+                <inputEntry id="UnaryTests_03g3ci0">
+                    <text>"Spareribs"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0jb8hau">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_1kr45vj">
+                    <text>"Aecht Schlenkerla Rauchbier"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-8">
+                <inputEntry id="UnaryTests_1ckv0bb">
+                    <text>"Stew"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1joyits">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_139n7gl">
+                    <text>"Guiness"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-9">
+                <inputEntry id="UnaryTests_05rspiy">
+                    <text>"Roastbeef"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_15yl6ki">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0bzfo47">
+                    <text>"Bordeaux"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-10">
+                <inputEntry id="UnaryTests_0mk75lc">
+                    <text>"Steak","Dry Aged Gourmet Steak","Light Salad and a nice Steak"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_18uxmko">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_00nwn3e">
+                    <text>"Pinot Noir"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-11">
+                <inputEntry id="UnaryTests_11o8pqj">
+                    <text/>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1298ow3">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0z18erz">
+                    <text>"Apple Juice"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-12">
+                <inputEntry id="UnaryTests_0shocr0">
+                    <text/>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0nblyrk">
+                    <text>false</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0s2fq8r">
+                    <text>"Water"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision id="dish" name="Dish">
+
+        <informationRequirement id="InformationRequirement_0xbr982">
+            <requiredInput href="#InputData_0rin549"/>
+        </informationRequirement>
+        <informationRequirement id="InformationRequirement_0s36klr">
+            <requiredInput href="#InputData_1axnom3"/>
+        </informationRequirement>
+
+        <authorityRequirement id="AuthorityRequirement_0h647jo">
+            <requiredAuthority href="#KnowledgeSource_0b8hnqo"/>
+        </authorityRequirement>
+
+        <decisionTable id="DecisionTable_040j91i">
+            <input id="InputClause_0bbq1z8" label="Season">
+                <inputExpression id="LiteralExpression_1iwaqcz" typeRef="string">
+                    <text>Season</text>
+                </inputExpression>
+            </input>
+            <input id="InputClause_0pcbpc9" label="How many guests">
+                <inputExpression id="LiteralExpression_1uu3xe6" typeRef="integer">
+                    <text>Number of Guests</text>
+                </inputExpression>
+            </input>
+            <output id="OutputClause_0lfar1z" label="Dish" name="desiredDish" typeRef="string"/>
+            <rule id="row-884555325-1">
+                <description>Default value</description>
+                <inputEntry id="UnaryTests_0cy7usy">
+                    <text>not("Fall", "Winter", "Spring", "Summer")</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0ww352f">
+                    <text>&gt;= 0</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_07xyqqp">
+                    <text>"Instant Soup"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-1">
+                <inputEntry id="UnaryTests_06z2ju4">
+                    <text>"Fall"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0ph5qbt">
+                    <text>&lt;= 8</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0sntjhd">
+                    <text>"Spareribs"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-2">
+                <inputEntry id="UnaryTests_0o5o0mm">
+                    <text>"Winter"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0rtyr8x">
+                    <text>&lt;= 8</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_15nybba">
+                    <text>"Roastbeef"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-3">
+                <inputEntry id="UnaryTests_1f00omt">
+                    <text>"Spring"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_03yxt5d">
+                    <text>&lt;= 4</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_1ki86jo">
+                    <text>"Dry Aged Gourmet Steak"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-4">
+                <description>Save money</description>
+                <inputEntry id="UnaryTests_18csep1">
+                    <text>"Spring"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1lt4o3q">
+                    <text>[5..8]</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_1h969t1">
+                    <text>"Steak"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-5">
+                <description>Less effort</description>
+                <inputEntry id="UnaryTests_0cp9scy">
+                    <text>"Fall","Winter","Spring"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1to1xxg">
+                    <text>&gt; 8</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0fjt4uo">
+                    <text>"Stew"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-6">
+                <description>Hey, why not?</description>
+                <inputEntry id="UnaryTests_0s5azk4">
+                    <text>"Summer"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1nuzyri">
+                    <text/>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0nspzk1">
+                    <text>"Light Salad and a nice Steak"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <inputData id="InputData_0rin549" name="Season"/>
+    <inputData id="InputData_1axnom3" name="Number of Guests"/>
+    <inputData id="InputData_0pgvdj9" name="Guests with children?"/>
+
+    <knowledgeSource id="KnowledgeSource_0b8hnqo" name="Men's Cookbook"/>
+
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="DMNDiagram_0i21c0s">
+            <dmndi:DMNShape id="DMNShape_0a1lk6d" dmnElementRef="beverages">
+                <dc:Bounds height="80" width="180" x="540" y="86"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="DMNEdge_1czaglz" dmnElementRef="InformationRequirement_1xvojck">
+                <di:waypoint x="713" y="239"/>
+                <di:waypoint x="660" y="186"/>
+                <di:waypoint x="660" y="166"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="DMNEdge_03cgt9t" dmnElementRef="InformationRequirement_083jsex">
+                <di:waypoint x="473" y="240"/>
+                <di:waypoint x="600" y="186"/>
+                <di:waypoint x="600" y="166"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNShape id="DMNShape_0rz3blq" dmnElementRef="dish">
+                <dc:Bounds height="80" width="180" x="383" y="240"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="DMNEdge_0f7wakd" dmnElementRef="AuthorityRequirement_0h647jo">
+                <di:waypoint x="261" y="285"/>
+                <di:waypoint x="383" y="278"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="DMNEdge_0c10itu" dmnElementRef="InformationRequirement_0xbr982">
+                <di:waypoint x="377" y="399"/>
+                <di:waypoint x="437" y="320"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="DMNEdge_1uk8cqg" dmnElementRef="InformationRequirement_0s36klr">
+                <di:waypoint x="566" y="401"/>
+                <di:waypoint x="508" y="320"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNShape id="DMNShape_00sc46j" dmnElementRef="InputData_0rin549">
+                <dc:Bounds height="45" width="125" x="296" y="399"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="DMNShape_095ntfb" dmnElementRef="InputData_1axnom3">
+                <dc:Bounds height="45" width="125" x="519" y="401"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="DMNShape_0aea4xy" dmnElementRef="InputData_0pgvdj9">
+                <dc:Bounds height="45" width="125" x="650" y="239"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="DMNShape_0bugmbv" dmnElementRef="KnowledgeSource_0b8hnqo">
+                <dc:Bounds height="63" width="100" x="161" y="253"/>
+            </dmndi:DMNShape>
+        </dmndi:DMNDiagram>
+    </dmndi:DMNDI>
+</definitions>

--- a/model-evaluator/src/tests/simulation/simulation_v14.dmn
+++ b/model-evaluator/src/tests/simulation/simulation_v14.dmn
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20211108/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="dinnerDecisions"
+             name="Dinner Decisions"
+             namespace="https://camunda.org/schema/1.0/dmn"
+             exporter="Camunda Modeler"
+             exporterVersion="4.0.0">
+    <decision id="beverages" name="Beverages">
+
+        <informationRequirement id="InformationRequirement_1xvojck">
+            <requiredInput href="#InputData_0pgvdj9"/>
+        </informationRequirement>
+        <informationRequirement id="InformationRequirement_083jsex">
+            <requiredDecision href="#dish"/>
+        </informationRequirement>
+
+        <decisionTable id="DecisionTable_07q05jb" hitPolicy="COLLECT">
+            <input id="InputClause_1acmlkd" label="Dish">
+                <inputExpression id="LiteralExpression_0bqgrlg" typeRef="string">
+                    <text>Dish</text>
+                </inputExpression>
+            </input>
+            <input id="InputClause_0bo3uen" label="Guests with children">
+                <inputExpression id="LiteralExpression_0d6l79o" typeRef="boolean">
+                    <text>Guests with children?</text>
+                </inputExpression>
+            </input>
+            <output id="OuputClause_99999" label="Beverages" name="beverages" typeRef="string"/>
+            <rule id="row-506282952-7">
+                <description>Tough Stuff</description>
+                <inputEntry id="UnaryTests_03g3ci0">
+                    <text>"Spareribs"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0jb8hau">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_1kr45vj">
+                    <text>"Aecht Schlenkerla Rauchbier"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-8">
+                <inputEntry id="UnaryTests_1ckv0bb">
+                    <text>"Stew"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1joyits">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_139n7gl">
+                    <text>"Guiness"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-9">
+                <inputEntry id="UnaryTests_05rspiy">
+                    <text>"Roastbeef"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_15yl6ki">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0bzfo47">
+                    <text>"Bordeaux"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-10">
+                <inputEntry id="UnaryTests_0mk75lc">
+                    <text>"Steak","Dry Aged Gourmet Steak","Light Salad and a nice Steak"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_18uxmko">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_00nwn3e">
+                    <text>"Pinot Noir"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-11">
+                <inputEntry id="UnaryTests_11o8pqj">
+                    <text/>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1298ow3">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0z18erz">
+                    <text>"Apple Juice"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-12">
+                <inputEntry id="UnaryTests_0shocr0">
+                    <text/>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0nblyrk">
+                    <text>false</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0s2fq8r">
+                    <text>"Water"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision id="dish" name="Dish">
+
+        <informationRequirement id="InformationRequirement_0xbr982">
+            <requiredInput href="#InputData_0rin549"/>
+        </informationRequirement>
+        <informationRequirement id="InformationRequirement_0s36klr">
+            <requiredInput href="#InputData_1axnom3"/>
+        </informationRequirement>
+
+        <authorityRequirement id="AuthorityRequirement_0h647jo">
+            <requiredAuthority href="#KnowledgeSource_0b8hnqo"/>
+        </authorityRequirement>
+
+        <decisionTable id="DecisionTable_040j91i">
+            <input id="InputClause_0bbq1z8" label="Season">
+                <inputExpression id="LiteralExpression_1iwaqcz" typeRef="string">
+                    <text>Season</text>
+                </inputExpression>
+            </input>
+            <input id="InputClause_0pcbpc9" label="How many guests">
+                <inputExpression id="LiteralExpression_1uu3xe6" typeRef="integer">
+                    <text>Number of Guests</text>
+                </inputExpression>
+            </input>
+            <output id="OutputClause_0lfar1z" label="Dish" name="desiredDish" typeRef="string"/>
+            <rule id="row-884555325-1">
+                <description>Default value</description>
+                <inputEntry id="UnaryTests_0cy7usy">
+                    <text>not("Fall", "Winter", "Spring", "Summer")</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0ww352f">
+                    <text>&gt;= 0</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_07xyqqp">
+                    <text>"Instant Soup"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-1">
+                <inputEntry id="UnaryTests_06z2ju4">
+                    <text>"Fall"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0ph5qbt">
+                    <text>&lt;= 8</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0sntjhd">
+                    <text>"Spareribs"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-2">
+                <inputEntry id="UnaryTests_0o5o0mm">
+                    <text>"Winter"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0rtyr8x">
+                    <text>&lt;= 8</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_15nybba">
+                    <text>"Roastbeef"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-3">
+                <inputEntry id="UnaryTests_1f00omt">
+                    <text>"Spring"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_03yxt5d">
+                    <text>&lt;= 4</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_1ki86jo">
+                    <text>"Dry Aged Gourmet Steak"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-4">
+                <description>Save money</description>
+                <inputEntry id="UnaryTests_18csep1">
+                    <text>"Spring"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1lt4o3q">
+                    <text>[5..8]</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_1h969t1">
+                    <text>"Steak"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-5">
+                <description>Less effort</description>
+                <inputEntry id="UnaryTests_0cp9scy">
+                    <text>"Fall","Winter","Spring"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1to1xxg">
+                    <text>&gt; 8</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0fjt4uo">
+                    <text>"Stew"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-6">
+                <description>Hey, why not?</description>
+                <inputEntry id="UnaryTests_0s5azk4">
+                    <text>"Summer"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1nuzyri">
+                    <text/>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0nspzk1">
+                    <text>"Light Salad and a nice Steak"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <inputData id="InputData_0rin549" name="Season"/>
+    <inputData id="InputData_1axnom3" name="Number of Guests"/>
+    <inputData id="InputData_0pgvdj9" name="Guests with children?"/>
+
+    <knowledgeSource id="KnowledgeSource_0b8hnqo" name="Men's Cookbook"/>
+
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="DMNDiagram_0i21c0s">
+            <dmndi:DMNShape id="DMNShape_0a1lk6d" dmnElementRef="beverages">
+                <dc:Bounds height="80" width="180" x="540" y="86"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="DMNEdge_1czaglz" dmnElementRef="InformationRequirement_1xvojck">
+                <di:waypoint x="713" y="239"/>
+                <di:waypoint x="660" y="186"/>
+                <di:waypoint x="660" y="166"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="DMNEdge_03cgt9t" dmnElementRef="InformationRequirement_083jsex">
+                <di:waypoint x="473" y="240"/>
+                <di:waypoint x="600" y="186"/>
+                <di:waypoint x="600" y="166"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNShape id="DMNShape_0rz3blq" dmnElementRef="dish">
+                <dc:Bounds height="80" width="180" x="383" y="240"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="DMNEdge_0f7wakd" dmnElementRef="AuthorityRequirement_0h647jo">
+                <di:waypoint x="261" y="285"/>
+                <di:waypoint x="383" y="278"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="DMNEdge_0c10itu" dmnElementRef="InformationRequirement_0xbr982">
+                <di:waypoint x="377" y="399"/>
+                <di:waypoint x="437" y="320"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="DMNEdge_1uk8cqg" dmnElementRef="InformationRequirement_0s36klr">
+                <di:waypoint x="566" y="401"/>
+                <di:waypoint x="508" y="320"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNShape id="DMNShape_00sc46j" dmnElementRef="InputData_0rin549">
+                <dc:Bounds height="45" width="125" x="296" y="399"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="DMNShape_095ntfb" dmnElementRef="InputData_1axnom3">
+                <dc:Bounds height="45" width="125" x="519" y="401"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="DMNShape_0aea4xy" dmnElementRef="InputData_0pgvdj9">
+                <dc:Bounds height="45" width="125" x="650" y="239"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="DMNShape_0bugmbv" dmnElementRef="KnowledgeSource_0b8hnqo">
+                <dc:Bounds height="63" width="100" x="161" y="253"/>
+            </dmndi:DMNShape>
+        </dmndi:DMNDiagram>
+    </dmndi:DMNDI>
+</definitions>

--- a/model-evaluator/src/tests/simulation/simulation_v15.dmn
+++ b/model-evaluator/src/tests/simulation/simulation_v15.dmn
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20230324/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="dinnerDecisions"
+             name="Dinner Decisions"
+             namespace="https://camunda.org/schema/1.0/dmn"
+             exporter="Camunda Modeler"
+             exporterVersion="4.0.0">
+    <decision id="beverages" name="Beverages">
+
+        <informationRequirement id="InformationRequirement_1xvojck">
+            <requiredInput href="#InputData_0pgvdj9"/>
+        </informationRequirement>
+        <informationRequirement id="InformationRequirement_083jsex">
+            <requiredDecision href="#dish"/>
+        </informationRequirement>
+
+        <decisionTable id="DecisionTable_07q05jb" hitPolicy="COLLECT">
+            <input id="InputClause_1acmlkd" label="Dish">
+                <inputExpression id="LiteralExpression_0bqgrlg" typeRef="string">
+                    <text>Dish</text>
+                </inputExpression>
+            </input>
+            <input id="InputClause_0bo3uen" label="Guests with children">
+                <inputExpression id="LiteralExpression_0d6l79o" typeRef="boolean">
+                    <text>Guests with children?</text>
+                </inputExpression>
+            </input>
+            <output id="OuputClause_99999" label="Beverages" name="beverages" typeRef="string"/>
+            <rule id="row-506282952-7">
+                <description>Tough Stuff</description>
+                <inputEntry id="UnaryTests_03g3ci0">
+                    <text>"Spareribs"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0jb8hau">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_1kr45vj">
+                    <text>"Aecht Schlenkerla Rauchbier"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-8">
+                <inputEntry id="UnaryTests_1ckv0bb">
+                    <text>"Stew"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1joyits">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_139n7gl">
+                    <text>"Guiness"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-9">
+                <inputEntry id="UnaryTests_05rspiy">
+                    <text>"Roastbeef"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_15yl6ki">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0bzfo47">
+                    <text>"Bordeaux"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-10">
+                <inputEntry id="UnaryTests_0mk75lc">
+                    <text>"Steak","Dry Aged Gourmet Steak","Light Salad and a nice Steak"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_18uxmko">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_00nwn3e">
+                    <text>"Pinot Noir"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-11">
+                <inputEntry id="UnaryTests_11o8pqj">
+                    <text/>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1298ow3">
+                    <text>true</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0z18erz">
+                    <text>"Apple Juice"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-12">
+                <inputEntry id="UnaryTests_0shocr0">
+                    <text/>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0nblyrk">
+                    <text>false</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0s2fq8r">
+                    <text>"Water"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <decision id="dish" name="Dish">
+
+        <informationRequirement id="InformationRequirement_0xbr982">
+            <requiredInput href="#InputData_0rin549"/>
+        </informationRequirement>
+        <informationRequirement id="InformationRequirement_0s36klr">
+            <requiredInput href="#InputData_1axnom3"/>
+        </informationRequirement>
+
+        <authorityRequirement id="AuthorityRequirement_0h647jo">
+            <requiredAuthority href="#KnowledgeSource_0b8hnqo"/>
+        </authorityRequirement>
+
+        <decisionTable id="DecisionTable_040j91i">
+            <input id="InputClause_0bbq1z8" label="Season">
+                <inputExpression id="LiteralExpression_1iwaqcz" typeRef="string">
+                    <text>Season</text>
+                </inputExpression>
+            </input>
+            <input id="InputClause_0pcbpc9" label="How many guests">
+                <inputExpression id="LiteralExpression_1uu3xe6" typeRef="integer">
+                    <text>Number of Guests</text>
+                </inputExpression>
+            </input>
+            <output id="OutputClause_0lfar1z" label="Dish" name="desiredDish" typeRef="string"/>
+            <rule id="row-884555325-1">
+                <description>Default value</description>
+                <inputEntry id="UnaryTests_0cy7usy">
+                    <text>not("Fall", "Winter", "Spring", "Summer")</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0ww352f">
+                    <text>&gt;= 0</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_07xyqqp">
+                    <text>"Instant Soup"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-1">
+                <inputEntry id="UnaryTests_06z2ju4">
+                    <text>"Fall"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0ph5qbt">
+                    <text>&lt;= 8</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0sntjhd">
+                    <text>"Spareribs"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-2">
+                <inputEntry id="UnaryTests_0o5o0mm">
+                    <text>"Winter"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_0rtyr8x">
+                    <text>&lt;= 8</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_15nybba">
+                    <text>"Roastbeef"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-3">
+                <inputEntry id="UnaryTests_1f00omt">
+                    <text>"Spring"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_03yxt5d">
+                    <text>&lt;= 4</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_1ki86jo">
+                    <text>"Dry Aged Gourmet Steak"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-4">
+                <description>Save money</description>
+                <inputEntry id="UnaryTests_18csep1">
+                    <text>"Spring"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1lt4o3q">
+                    <text>[5..8]</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_1h969t1">
+                    <text>"Steak"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-5">
+                <description>Less effort</description>
+                <inputEntry id="UnaryTests_0cp9scy">
+                    <text>"Fall","Winter","Spring"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1to1xxg">
+                    <text>&gt; 8</text>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0fjt4uo">
+                    <text>"Stew"</text>
+                </outputEntry>
+            </rule>
+            <rule id="row-506282952-6">
+                <description>Hey, why not?</description>
+                <inputEntry id="UnaryTests_0s5azk4">
+                    <text>"Summer"</text>
+                </inputEntry>
+                <inputEntry id="UnaryTests_1nuzyri">
+                    <text/>
+                </inputEntry>
+                <outputEntry id="LiteralExpression_0nspzk1">
+                    <text>"Light Salad and a nice Steak"</text>
+                </outputEntry>
+            </rule>
+        </decisionTable>
+    </decision>
+
+    <inputData id="InputData_0rin549" name="Season"/>
+    <inputData id="InputData_1axnom3" name="Number of Guests"/>
+    <inputData id="InputData_0pgvdj9" name="Guests with children?"/>
+
+    <knowledgeSource id="KnowledgeSource_0b8hnqo" name="Men's Cookbook"/>
+
+    <dmndi:DMNDI>
+        <dmndi:DMNDiagram id="DMNDiagram_0i21c0s">
+            <dmndi:DMNShape id="DMNShape_0a1lk6d" dmnElementRef="beverages">
+                <dc:Bounds height="80" width="180" x="540" y="86"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="DMNEdge_1czaglz" dmnElementRef="InformationRequirement_1xvojck">
+                <di:waypoint x="713" y="239"/>
+                <di:waypoint x="660" y="186"/>
+                <di:waypoint x="660" y="166"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="DMNEdge_03cgt9t" dmnElementRef="InformationRequirement_083jsex">
+                <di:waypoint x="473" y="240"/>
+                <di:waypoint x="600" y="186"/>
+                <di:waypoint x="600" y="166"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNShape id="DMNShape_0rz3blq" dmnElementRef="dish">
+                <dc:Bounds height="80" width="180" x="383" y="240"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNEdge id="DMNEdge_0f7wakd" dmnElementRef="AuthorityRequirement_0h647jo">
+                <di:waypoint x="261" y="285"/>
+                <di:waypoint x="383" y="278"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="DMNEdge_0c10itu" dmnElementRef="InformationRequirement_0xbr982">
+                <di:waypoint x="377" y="399"/>
+                <di:waypoint x="437" y="320"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNEdge id="DMNEdge_1uk8cqg" dmnElementRef="InformationRequirement_0s36klr">
+                <di:waypoint x="566" y="401"/>
+                <di:waypoint x="508" y="320"/>
+            </dmndi:DMNEdge>
+            <dmndi:DMNShape id="DMNShape_00sc46j" dmnElementRef="InputData_0rin549">
+                <dc:Bounds height="45" width="125" x="296" y="399"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="DMNShape_095ntfb" dmnElementRef="InputData_1axnom3">
+                <dc:Bounds height="45" width="125" x="519" y="401"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="DMNShape_0aea4xy" dmnElementRef="InputData_0pgvdj9">
+                <dc:Bounds height="45" width="125" x="650" y="239"/>
+            </dmndi:DMNShape>
+            <dmndi:DMNShape id="DMNShape_0bugmbv" dmnElementRef="KnowledgeSource_0b8hnqo">
+                <dc:Bounds height="63" width="100" x="161" y="253"/>
+            </dmndi:DMNShape>
+        </dmndi:DMNDiagram>
+    </dmndi:DMNDI>
+</definitions>

--- a/model/src/parser.rs
+++ b/model/src/parser.rs
@@ -73,7 +73,7 @@ impl ModelParser {
   /// Parses a collection of [ItemDefinition].
   fn parse_item_definitions(&mut self, node: &Node, child_name: &str) -> Result<Vec<ItemDefinition>> {
     let mut items = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == child_name) {
+    for ref child_node in node.children().filter(name_eq(child_name)) {
       items.push(self.parse_item_definition(child_node)?);
     }
     Ok(items)
@@ -103,7 +103,7 @@ impl ModelParser {
 
   /// Parses optional function item.
   fn parse_function_item(&self, node: &Node) -> Result<Option<FunctionItem>> {
-    if let Some(ref n) = node.children().find(|n| n.tag_name().name() == NODE_FUNCTION_ITEM) {
+    if let Some(ref n) = node.children().find(name_eq(NODE_FUNCTION_ITEM)) {
       Ok(Some(FunctionItem {
         output_type_ref: optional_attribute(n, ATTR_OUTPUT_TYPE_REF),
         parameters: self.parse_vec_information_item_child(n, NODE_PARAMETERS)?,
@@ -115,7 +115,7 @@ impl ModelParser {
 
   /// Parsers unary tests.
   fn parse_unary_tests(&self, node: &Node, child_name: &str) -> Result<Option<UnaryTests>> {
-    if let Some(child_node) = node.children().find(|n| n.tag_name().name() == child_name) {
+    if let Some(child_node) = node.children().find(name_eq(child_name)) {
       Ok(Some(UnaryTests {
         text: optional_child_required_content(&child_node, NODE_TEXT)?,
         expression_language: optional_attribute(&child_node, ATTR_EXPRESSION_LANGUAGE),
@@ -139,7 +139,7 @@ impl ModelParser {
   /// Parses `inputData` nodes.
   fn parse_input_data_nodes(&self, node: &Node) -> Result<Vec<DrgElement>> {
     let mut input_data_items = vec![];
-    for ref child_node in node.children().filter(f_name(NODE_INPUT_DATA)) {
+    for ref child_node in node.children().filter(name_eq(NODE_INPUT_DATA)) {
       let name = required_name(child_node)?;
       let feel_name = required_feel_name(child_node)?;
       let variable = self
@@ -165,7 +165,7 @@ impl ModelParser {
   /// Parses `decision` nodes.
   fn parse_decision_nodes(&mut self, node: &Node) -> Result<Vec<DrgElement>> {
     let mut decision_items = vec![];
-    for ref child_node in node.children().filter(f_name(NODE_DECISION)) {
+    for ref child_node in node.children().filter(name_eq(NODE_DECISION)) {
       let name = required_name(child_node)?;
       let feel_name = required_feel_name(child_node)?;
       let variable = self
@@ -197,7 +197,7 @@ impl ModelParser {
   /// Parses `businessKnowledgeModel` nodes.
   fn parse_business_knowledge_model_nodes(&mut self, node: &Node) -> Result<Vec<DrgElement>> {
     let mut parsed_items = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_BUSINESS_KNOWLEDGE_MODEL) {
+    for ref child_node in node.children().filter(name_eq(NODE_BUSINESS_KNOWLEDGE_MODEL)) {
       let name = required_name(child_node)?;
       let feel_name = required_feel_name(child_node)?;
       let variable = self
@@ -226,7 +226,7 @@ impl ModelParser {
   /// Parses decision services.
   fn parse_decision_services(&self, node: &Node) -> Result<Vec<DrgElement>> {
     let mut drg_elements = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_DECISION_SERVICE) {
+    for ref child_node in node.children().filter(name_eq(NODE_DECISION_SERVICE)) {
       let name = required_name(child_node)?;
       let feel_name = required_feel_name(child_node)?;
       let variable = self
@@ -256,7 +256,7 @@ impl ModelParser {
   /// Parses knowledge sources.
   fn parse_knowledge_sources(&mut self, node: &Node) -> Result<Vec<DrgElement>> {
     let mut drg_elements = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_KNOWLEDGE_SOURCE) {
+    for ref child_node in node.children().filter(name_eq(NODE_KNOWLEDGE_SOURCE)) {
       let knowledge_source = KnowledgeSource {
         namespace: self.namespace.clone(),
         model_name: self.model_name.clone(),
@@ -276,7 +276,7 @@ impl ModelParser {
 
   fn required_hrefs_in_child_nodes(&self, node: &Node, child_name: &str) -> Result<Vec<HRef>> {
     let mut hrefs = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == child_name) {
+    for ref child_node in node.children().filter(name_eq(child_name)) {
       let text = required_attribute(child_node, ATTR_HREF)?;
       let href = HRef::try_from(text.as_str())?;
       hrefs.push(href);
@@ -285,7 +285,7 @@ impl ModelParser {
   }
 
   fn parse_function_definition_child(&self, node: &Node, child_name: &str) -> Result<Option<FunctionDefinition>> {
-    if let Some(child_node) = node.children().find(|n| n.tag_name().name() == child_name) {
+    if let Some(child_node) = node.children().find(name_eq(child_name)) {
       Ok(Some(self.parse_function_definition(&child_node)?))
     } else {
       Ok(None)
@@ -293,7 +293,7 @@ impl ModelParser {
   }
 
   fn parse_optional_function_definition(&self, node: &Node) -> Result<Option<FunctionDefinition>> {
-    if let Some(child_node) = node.children().find(|n| n.tag_name().name() == NODE_FUNCTION_DEFINITION) {
+    if let Some(child_node) = node.children().find(name_eq(NODE_FUNCTION_DEFINITION)) {
       Ok(Some(self.parse_function_definition(&child_node)?))
     } else {
       Ok(None)
@@ -332,7 +332,7 @@ impl ModelParser {
   /// Parses business context elements like performance indicators and organisational units.
   fn parse_business_context_elements(&self, node: &Node) -> Result<Vec<BusinessContextElementInstance>> {
     let mut business_context_elements = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_PERFORMANCE_INDICATOR) {
+    for ref child_node in node.children().filter(name_eq(NODE_PERFORMANCE_INDICATOR)) {
       let performance_indicator = PerformanceIndicator {
         namespace: self.namespace.clone(),
         model_name: self.model_name.clone(),
@@ -348,7 +348,7 @@ impl ModelParser {
       };
       business_context_elements.push(BusinessContextElementInstance::PerformanceIndicator(performance_indicator));
     }
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_ORGANISATION_UNIT) {
+    for ref child_node in node.children().filter(name_eq(NODE_ORGANISATION_UNIT)) {
       let organisation_unit = OrganizationUnit {
         namespace: self.namespace.clone(),
         model_name: self.model_name.clone(),
@@ -371,7 +371,7 @@ impl ModelParser {
   /// Parses a collection of [Imports](Import).
   fn parse_imports(&self, node: &Node) -> Result<Vec<Import>> {
     let mut imports = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_IMPORT) {
+    for ref child_node in node.children().filter(name_eq(NODE_IMPORT)) {
       let import = Import {
         namespace: required_uri(child_node, ATTR_NAMESPACE)?,
         model_name: self.model_name.clone(),
@@ -392,7 +392,7 @@ impl ModelParser {
 
   /// Parses a required [InformationItem], contained in a child node having the specified name.
   fn parse_req_information_item_child(&self, node: &Node, child_name: &str) -> Result<InformationItem> {
-    if let Some(child_node) = node.children().find(|n| n.tag_name().name() == child_name) {
+    if let Some(child_node) = node.children().find(name_eq(child_name)) {
       self.parse_information_item(&child_node)
     } else {
       Err(err_xml_expected_mandatory_child_node(&node_name_pos(node), child_name))
@@ -401,7 +401,7 @@ impl ModelParser {
 
   /// Parses an optional [InformationItem], contained in a child node having the specified name.
   fn parse_opt_information_item_child(&self, node: &Node, child_name: &str) -> Result<Option<InformationItem>> {
-    Ok(if let Some(child_node) = node.children().find(|n| n.tag_name().name() == child_name) {
+    Ok(if let Some(child_node) = node.children().find(name_eq(child_name)) {
       Some(self.parse_information_item(&child_node)?)
     } else {
       None
@@ -411,7 +411,7 @@ impl ModelParser {
   /// Parses a collection of [InformationItem]s contained in multiple child nodes having the specified name.
   fn parse_vec_information_item_child(&self, node: &Node, child_name: &str) -> Result<Vec<InformationItem>> {
     let mut information_items = vec![];
-    for child_node in node.children().filter(|n| n.tag_name().name() == child_name) {
+    for child_node in node.children().filter(name_eq(child_name)) {
       information_items.push(self.parse_information_item(&child_node)?);
     }
     Ok(information_items)
@@ -454,7 +454,7 @@ impl ModelParser {
   /// Parses information requirements.
   fn parse_information_requirements(&mut self, node: &Node, child_name: &str) -> Result<Vec<InformationRequirement>> {
     let mut information_requirement_items = vec![];
-    for child_node in node.children().filter(|n| n.tag_name().name() == child_name) {
+    for child_node in node.children().filter(name_eq(child_name)) {
       information_requirement_items.push(self.parse_information_requirement(&child_node)?);
     }
     Ok(information_requirement_items)
@@ -479,7 +479,7 @@ impl ModelParser {
   /// Parses knowledge requirements.
   fn parse_knowledge_requirements(&mut self, node: &Node, child_name: &str) -> Result<Vec<KnowledgeRequirement>> {
     let mut knowledge_requirement_items = vec![];
-    for child_node in node.children().filter(|n| n.tag_name().name() == child_name) {
+    for child_node in node.children().filter(name_eq(child_name)) {
       knowledge_requirement_items.push(self.parse_knowledge_requirement(&child_node)?);
     }
     Ok(knowledge_requirement_items)
@@ -503,7 +503,7 @@ impl ModelParser {
   /// Parses authority requirements.
   fn parse_authority_requirements(&mut self, node: &Node, child_name: &str) -> Result<Vec<AuthorityRequirement>> {
     let mut authority_requirement_items = vec![];
-    for child_node in node.children().filter(|n| n.tag_name().name() == child_name) {
+    for child_node in node.children().filter(name_eq(child_name)) {
       authority_requirement_items.push(self.parse_authority_requirement(&child_node)?);
     }
     Ok(authority_requirement_items)
@@ -609,7 +609,7 @@ impl ModelParser {
   }
 
   fn parse_optional_decision_table(&self, node: &Node) -> Result<Option<DecisionTable>> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_DECISION_TABLE) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_DECISION_TABLE)) {
       return Ok(Some(self.parse_decision_table(child_node)?));
     }
     Ok(None)
@@ -639,7 +639,7 @@ impl ModelParser {
 
   fn parse_decision_table_inputs(&self, node: &Node) -> Result<Vec<InputClause>> {
     let mut input_clauses = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_INPUT) {
+    for ref child_node in node.children().filter(name_eq(NODE_INPUT)) {
       input_clauses.push(self.parse_decision_table_input(child_node)?);
     }
     Ok(input_clauses)
@@ -664,7 +664,7 @@ impl ModelParser {
 
   fn parse_decision_table_outputs(&self, node: &Node) -> Result<Vec<OutputClause>> {
     let mut output_clauses = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_OUTPUT) {
+    for ref child_node in node.children().filter(name_eq(NODE_OUTPUT)) {
       output_clauses.push(self.parse_decision_table_output(child_node)?);
     }
     Ok(output_clauses)
@@ -691,7 +691,7 @@ impl ModelParser {
 
   fn parse_decision_table_rules(&self, node: &Node) -> Result<Vec<DecisionRule>> {
     let mut rules = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_RULE) {
+    for ref child_node in node.children().filter(name_eq(NODE_RULE)) {
       rules.push(self.parse_decision_table_rule(child_node)?);
     }
     Ok(rules)
@@ -707,7 +707,7 @@ impl ModelParser {
 
   fn parse_decision_table_input_entries(&self, node: &Node) -> Result<Vec<InputEntry>> {
     let mut input_entries = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_INPUT_ENTRY) {
+    for ref child_node in node.children().filter(name_eq(NODE_INPUT_ENTRY)) {
       input_entries.push(self.parse_decision_table_input_entry(child_node)?);
     }
     Ok(input_entries)
@@ -730,7 +730,7 @@ impl ModelParser {
 
   fn parse_decision_table_output_entries(&self, node: &Node) -> Result<Vec<OutputEntry>> {
     let mut output_entries = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_OUTPUT_ENTRY) {
+    for ref child_node in node.children().filter(name_eq(NODE_OUTPUT_ENTRY)) {
       output_entries.push(self.parse_decision_table_output_entry(child_node)?);
     }
     Ok(output_entries)
@@ -743,7 +743,7 @@ impl ModelParser {
   }
 
   fn parse_optional_context(&self, node: &Node) -> Result<Option<Context>> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_CONTEXT) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_CONTEXT)) {
       return Ok(Some(self.parse_context(child_node)?));
     }
     Ok(None)
@@ -765,7 +765,7 @@ impl ModelParser {
 
   fn parse_context_entries(&self, node: &Node) -> Result<Vec<ContextEntry>> {
     let mut context_entries = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_CONTEXT_ENTRY) {
+    for ref child_node in node.children().filter(name_eq(NODE_CONTEXT_ENTRY)) {
       context_entries.push(ContextEntry {
         variable: self.parse_opt_information_item_child(child_node, NODE_VARIABLE)?,
         value: self.parse_required_child_expression_instance(child_node)?,
@@ -775,7 +775,7 @@ impl ModelParser {
   }
 
   fn parse_optional_invocation(&self, node: &Node) -> Result<Option<Invocation>> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_INVOCATION) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_INVOCATION)) {
       return Ok(Some(self.parse_invocation(child_node)?));
     }
     Ok(None)
@@ -798,7 +798,7 @@ impl ModelParser {
 
   fn parse_bindings(&self, node: &Node) -> Result<Vec<Binding>> {
     let mut bindings = vec![];
-    for ref child_node in node.children().filter(|n| n.tag_name().name() == NODE_BINDING) {
+    for ref child_node in node.children().filter(name_eq(NODE_BINDING)) {
       bindings.push(Binding {
         parameter: self.parse_req_information_item_child(child_node, NODE_PARAMETER)?,
         binding_formula: self.parse_optional_child_expression_instance(child_node)?,
@@ -810,7 +810,7 @@ impl ModelParser {
   /// Searches for the first node named 'list' among children of the specified `node`.
   /// When such node is found, then parses a list and returns it, otherwise returns [None].
   fn parse_optional_list(&self, node: &Node) -> Result<Option<List>> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_LIST) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_LIST)) {
       return Ok(Some(self.parse_list(child_node)?));
     }
     Ok(None)
@@ -844,7 +844,7 @@ impl ModelParser {
   /// Searches for the first node named 'literalExpression' among children of the specified `node`.
   /// When such node is found, then parses literal expression and returns it, otherwise returns [None].
   fn parse_optional_literal_expression(&self, node: &Node) -> Option<LiteralExpression> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_LITERAL_EXPRESSION) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_LITERAL_EXPRESSION)) {
       return Some(self.parse_literal_expression(child_node));
     }
     None
@@ -869,7 +869,7 @@ impl ModelParser {
   }
 
   fn parse_optional_relation(&self, node: &Node) -> Result<Option<Relation>> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_RELATION) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_RELATION)) {
       return Ok(Some(self.parse_relation(child_node)?));
     }
     Ok(None)
@@ -877,11 +877,11 @@ impl ModelParser {
 
   fn parse_relation(&self, node: &Node) -> Result<Relation> {
     let mut columns = vec![];
-    for ref column_node in node.children().filter(|n| n.tag_name().name() == NODE_COLUMN) {
+    for ref column_node in node.children().filter(name_eq(NODE_COLUMN)) {
       columns.push(self.parse_information_item(column_node)?);
     }
     let mut rows = vec![];
-    for ref row_node in node.children().filter(|n| n.tag_name().name() == NODE_ROW) {
+    for ref row_node in node.children().filter(name_eq(NODE_ROW)) {
       let mut elements = vec![];
       for ref expression_instance_node in row_node.children() {
         if expression_instance_node.tag_name().name() == NODE_LITERAL_EXPRESSION {
@@ -919,7 +919,7 @@ impl ModelParser {
   }
 
   fn parse_optional_conditional(&self, node: &Node) -> Result<Option<Conditional>> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_CONDITIONAL) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_CONDITIONAL)) {
       return Ok(Some(self.parse_conditional(child_node)?));
     }
     Ok(None)
@@ -945,7 +945,7 @@ impl ModelParser {
   }
 
   fn parse_optional_filter(&self, node: &Node) -> Result<Option<Filter>> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_FILTER) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_FILTER)) {
       return Ok(Some(self.parse_filter(child_node)?));
     }
     Ok(None)
@@ -969,7 +969,7 @@ impl ModelParser {
   }
 
   fn parse_optional_for(&self, node: &Node) -> Result<Option<For>> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_FOR) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_FOR)) {
       return Ok(Some(self.parse_for(child_node)?));
     }
     Ok(None)
@@ -994,7 +994,7 @@ impl ModelParser {
   }
 
   fn parse_optional_every(&self, node: &Node) -> Result<Option<Every>> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_EVERY) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_EVERY)) {
       return Ok(Some(self.parse_every(child_node)?));
     }
     Ok(None)
@@ -1019,7 +1019,7 @@ impl ModelParser {
   }
 
   fn parse_optional_some(&self, node: &Node) -> Result<Option<Some>> {
-    if let Some(ref child_node) = node.children().find(|n| n.tag_name().name() == NODE_SOME) {
+    if let Some(ref child_node) = node.children().find(name_eq(NODE_SOME)) {
       return Ok(Some(self.parse_some(child_node)?));
     }
     Ok(None)
@@ -1125,7 +1125,7 @@ impl ModelParser {
 
   /// Parse DMNDI part of the diagram definitions.
   fn parse_dmndi(&self, node: &Node) -> Result<Option<Dmndi>> {
-    if let Some(child_node) = node.children().find(|n| n.tag_name().name() == NODE_DMNDI) {
+    if let Some(child_node) = node.children().find(name_eq(NODE_DMNDI)) {
       let dmndi = Dmndi {
         styles: self.parse_styles(&child_node)?,
         diagrams: self.parse_diagrams(&child_node)?,
@@ -1138,7 +1138,7 @@ impl ModelParser {
   /// Parses shared styles defined in diagram.
   fn parse_styles(&self, node: &Node) -> Result<Vec<DmnStyle>> {
     let mut styles = vec![];
-    for child_node in node.children().filter(|n| n.tag_name().name() == NODE_DMNDI_STYLE) {
+    for child_node in node.children().filter(name_eq(NODE_DMNDI_STYLE)) {
       styles.push(self.parse_style(&child_node)?);
     }
     Ok(styles)
@@ -1164,7 +1164,7 @@ impl ModelParser {
 
   /// Parses the color definition.
   fn parse_optional_color(&self, node: &Node, child_name: &str) -> Result<Option<DcColor>> {
-    if let Some(color_node) = node.children().find(|n| n.tag_name().name() == child_name) {
+    if let Some(color_node) = node.children().find(name_eq(child_name)) {
       Ok(Some(DcColor {
         red: required_color_part(&color_node, ATTR_RED)?,
         green: required_color_part(&color_node, ATTR_GREEN)?,
@@ -1188,7 +1188,7 @@ impl ModelParser {
   /// Parses diagrams defined in [Dmndi].
   fn parse_diagrams(&self, node: &Node) -> Result<Vec<DmnDiagram>> {
     let mut diagrams = vec![];
-    for child_node in node.children().filter(|n| n.tag_name().name() == NODE_DMNDI_DMN_DIAGRAM) {
+    for child_node in node.children().filter(name_eq(NODE_DMNDI_DMN_DIAGRAM)) {
       diagrams.push(self.parse_diagram(&child_node)?);
     }
     Ok(diagrams)
@@ -1210,7 +1210,7 @@ impl ModelParser {
 
   /// Parses dimension.
   fn parse_dimension(&self, size_node: &Node) -> Result<Option<DcDimension>> {
-    if let Some(node) = size_node.children().find(|n| n.tag_name().name() == NODE_DMNDI_SIZE) {
+    if let Some(node) = size_node.children().find(name_eq(NODE_DMNDI_SIZE)) {
       Ok(Some(DcDimension {
         width: required_double(&node, ATTR_WIDTH)?,
         height: required_double(&node, ATTR_HEIGHT)?,
@@ -1223,10 +1223,10 @@ impl ModelParser {
   /// Parses diagram elements
   fn parse_diagram_elements(&self, size_node: &Node) -> Result<Vec<DmnDiagramElement>> {
     let mut diagram_element = vec![];
-    for child_node in size_node.children().filter(|n| n.tag_name().name() == NODE_DMNDI_DMN_SHAPE) {
+    for child_node in size_node.children().filter(name_eq(NODE_DMNDI_DMN_SHAPE)) {
       diagram_element.push(self.parse_shape(&child_node)?);
     }
-    for child_node in size_node.children().filter(|n| n.tag_name().name() == NODE_DMNDI_DMN_EDGE) {
+    for child_node in size_node.children().filter(name_eq(NODE_DMNDI_DMN_EDGE)) {
       diagram_element.push(self.parse_edge(&child_node)?);
     }
     Ok(diagram_element)
@@ -1257,7 +1257,7 @@ impl ModelParser {
 
   /// Parses bounds.
   fn parse_optional_bounds(&self, node: &Node) -> Result<Option<DcBounds>> {
-    if let Some(child_node) = node.children().find(|n| n.tag_name().name() == NODE_DMNDI_BOUNDS) {
+    if let Some(child_node) = node.children().find(name_eq(NODE_DMNDI_BOUNDS)) {
       Ok(Some(DcBounds {
         x: required_double(&child_node, ATTR_X)?,
         y: required_double(&child_node, ATTR_Y)?,
@@ -1271,7 +1271,7 @@ impl ModelParser {
 
   /// Parses divider line.
   fn parse_divider_line(&self, node: &Node) -> Result<Option<DmnDecisionServiceDividerLine>> {
-    if let Some(child_node) = node.children().find(|n| n.tag_name().name() == NODE_DMNDI_DECISION_SERVICE_DIVIDER_LINE) {
+    if let Some(child_node) = node.children().find(name_eq(NODE_DMNDI_DECISION_SERVICE_DIVIDER_LINE)) {
       Ok(Some(DmnDecisionServiceDividerLine {
         id: optional_attribute(&child_node, ATTR_ID),
         way_points: self.parse_way_points(&child_node)?,
@@ -1300,7 +1300,7 @@ impl ModelParser {
   /// Parses way points.
   fn parse_way_points(&self, node: &Node) -> Result<Vec<DcPoint>> {
     let mut way_points = vec![];
-    for child_node in node.children().filter(|n| n.tag_name().name() == NODE_DMNDI_WAYPOINT) {
+    for child_node in node.children().filter(name_eq(NODE_DMNDI_WAYPOINT)) {
       way_points.push(self.parse_point(&child_node)?)
     }
     Ok(way_points)
@@ -1316,7 +1316,7 @@ impl ModelParser {
 
   /// Parses the label of the element.
   fn parse_label(&self, node: &Node) -> Result<Option<DmnLabel>> {
-    if let Some(child_node) = node.children().find(|n| n.tag_name().name() == NODE_DMNDI_LABEL) {
+    if let Some(child_node) = node.children().find(name_eq(NODE_DMNDI_LABEL)) {
       Ok(Some(DmnLabel {
         bounds: self.parse_optional_bounds(&child_node)?,
         text: optional_child_optional_content(&child_node, ATTR_LABEL_TEXT),
@@ -1391,7 +1391,7 @@ pub fn optional_child_required_href(node: &Node, child_name: &str) -> Result<Opt
 /// Returns required `href` attributes collected from optional child nodes.
 pub fn optional_children_required_href(node: &Node, child_name: &str) -> Result<Vec<HRef>> {
   let mut hrefs = vec![];
-  for ref child_node in node.children().filter(|n| n.tag_name().name() == child_name) {
+  for ref child_node in node.children().filter(name_eq(child_name)) {
     hrefs.push(required_href(child_node)?);
   }
   Ok(hrefs)

--- a/model/src/tests/parser/input_files/t_0010.dmn
+++ b/model/src/tests/parser/input_files/t_0010.dmn
@@ -5,10 +5,10 @@
 
     <description>
         This is an example of invalid model.
-        No variable defined in decision.
+        No required 'name' attribute is defined in decision.
     </description>
 
-    <decision name="one">
+    <decision>
         <literalExpression>
             <text>1</text>
         </literalExpression>

--- a/model/src/tests/parser/invalid_models.rs
+++ b/model/src/tests/parser/invalid_models.rs
@@ -93,7 +93,7 @@ fn _0010() {
   let definitions = parse(T_DMN_0010);
   assert!(definitions.is_err());
   assert_eq!(
-    r#"<ModelParserError> expected mandatory child node 'variable' in parent node 'decision' at [11:5]"#,
+    r#"<ModelParserError> expected value for mandatory attribute 'name' in node 'decision' at [11:5]"#,
     format!("{}", definitions.err().unwrap())
   )
 }

--- a/model/src/validators/schema_validator.rs
+++ b/model/src/validators/schema_validator.rs
@@ -129,7 +129,7 @@ impl SchemaValidator {
 
   /// Validates the `inputData` nodes.
   fn validate_input_data_nodes(&mut self, node: &Node) -> Result<()> {
-    for ref child_node in node.children().filter(|n| is(n, NODE_INPUT_DATA)) {
+    for ref child_node in node.children().filter(name_eq(NODE_INPUT_DATA)) {
       match self.dmn_version {
         DmnVersion::V13 | DmnVersion::V14 | DmnVersion::V15 => self.standard_checks(child_node, chk!(v13, V_INPUT_DATA))?,
       }
@@ -139,7 +139,7 @@ impl SchemaValidator {
 
   /// Validates the `decision` nodes.
   fn validate_decision_nodes(&mut self, node: &Node) -> Result<()> {
-    for ref child_node in node.children().filter(|n| is(n, NODE_DECISION)) {
+    for ref child_node in node.children().filter(name_eq(NODE_DECISION)) {
       match self.dmn_version {
         DmnVersion::V13 => self.standard_checks(child_node, chk!(v13, V_DECISION))?,
         DmnVersion::V14 | DmnVersion::V15 => self.standard_checks(child_node, chk!(v14, V_DECISION))?,
@@ -150,7 +150,7 @@ impl SchemaValidator {
 
   /// Validates the `businessKnowledgeModel` nodes.
   fn validate_business_knowledge_model_nodes(&mut self, node: &Node) -> Result<()> {
-    for ref child_node in node.children().filter(|n| is(n, NODE_BUSINESS_KNOWLEDGE_MODEL)) {
+    for ref child_node in node.children().filter(name_eq(NODE_BUSINESS_KNOWLEDGE_MODEL)) {
       match self.dmn_version {
         DmnVersion::V13 | DmnVersion::V14 | DmnVersion::V15 => self.standard_checks(child_node, chk!(v13, V_BUSINESS_KNOWLEDGE_MODEL))?,
       }
@@ -160,7 +160,7 @@ impl SchemaValidator {
 
   /// Validates the `decisionService` nodes.
   fn validate_decision_service_nodes(&mut self, node: &Node) -> Result<()> {
-    for ref child_node in node.children().filter(|n| is(n, NODE_DECISION_SERVICE)) {
+    for ref child_node in node.children().filter(name_eq(NODE_DECISION_SERVICE)) {
       match self.dmn_version {
         DmnVersion::V13 | DmnVersion::V14 | DmnVersion::V15 => self.standard_checks(child_node, chk!(v13, V_DECISION_SERVICE))?,
       }
@@ -222,10 +222,6 @@ impl SchemaValidator {
     }
     Ok(())
   }
-}
-
-fn is(node: &Node, name: &str) -> bool {
-  node.tag_name().name() == name
 }
 
 mod v13 {

--- a/model/src/xml_utils.rs
+++ b/model/src/xml_utils.rs
@@ -223,7 +223,7 @@ pub fn req_child_req_content(node: &Node, child_name: &str) -> Result<String> {
 
 /// Returns the optional text contained in the required child node with specified name.
 pub fn req_child_opt_content(node: &Node, child_name: &str) -> Result<Option<String>> {
-  if let Some(child_node) = node.children().find(f_name(child_name)) {
+  if let Some(child_node) = node.children().find(name_eq(child_name)) {
     Ok(opt_content(&child_node))
   } else {
     Err(err_xml_expected_mandatory_child_node(&node_name_pos(node), child_name))
@@ -253,7 +253,7 @@ pub fn node_name_pos(node: &Node) -> String {
   format!("'{}' at [{}]", node.tag_name().name(), node.document().text_pos_at(node.range().start))
 }
 
-/// Returns a closure that checks if the node has specified name.
-pub fn f_name(name: &str) -> impl Fn(&Node) -> bool + '_ {
+/// Returns a closure that checks if the node's name is equal with specified value.
+pub fn name_eq(name: &str) -> impl Fn(&Node) -> bool + '_ {
   move |node: &Node| node.tag_name().name() == name
 }

--- a/model/src/xml_utils.rs
+++ b/model/src/xml_utils.rs
@@ -193,8 +193,8 @@ pub fn required_content(node: &Node) -> Result<String> {
   }
 }
 
-/// Returns optional textual content of the node.
-pub fn optional_content(node: &Node) -> Option<String> {
+/// Returns optional text content of the node with specified name.
+pub fn opt_content(node: &Node) -> Option<String> {
   node.text().map(|text| text.to_owned())
 }
 
@@ -212,10 +212,19 @@ pub fn optional_child<'a>(node: &'a Node, child_name: &str) -> Option<Node<'a, '
   node.children().find(|n| n.tag_name().name() == child_name)
 }
 
-/// Returns the required text content of the required child node.
-pub fn required_child_required_content(node: &Node, child_name: &str) -> Result<String> {
+/// Returns the required text contained in the required child node with specified name.
+pub fn req_child_req_content(node: &Node, child_name: &str) -> Result<String> {
   if let Some(child_node) = node.children().find(|n| n.tag_name().name() == child_name) {
     required_content(&child_node)
+  } else {
+    Err(err_xml_expected_mandatory_child_node(&node_name_pos(node), child_name))
+  }
+}
+
+/// Returns the optional text contained in the required child node with specified name.
+pub fn req_child_opt_content(node: &Node, child_name: &str) -> Result<Option<String>> {
+  if let Some(child_node) = node.children().find(f_name(child_name)) {
+    Ok(opt_content(&child_node))
   } else {
     Err(err_xml_expected_mandatory_child_node(&node_name_pos(node), child_name))
   }
@@ -233,7 +242,7 @@ pub fn optional_child_required_content(node: &Node, child_name: &str) -> Result<
 /// Returns the optional content of the optional child node.
 pub fn optional_child_optional_content(node: &Node, child_name: &str) -> Option<String> {
   if let Some(child_node) = node.children().find(|n| n.tag_name().name() == child_name) {
-    optional_content(&child_node)
+    opt_content(&child_node)
   } else {
     None
   }
@@ -242,4 +251,9 @@ pub fn optional_child_optional_content(node: &Node, child_name: &str) -> Option<
 /// Utility function that returns the node's name with its position in the original document.
 pub fn node_name_pos(node: &Node) -> String {
   format!("'{}' at [{}]", node.tag_name().name(), node.document().text_pos_at(node.range().start))
+}
+
+/// Returns a closure that checks if the node has specified name.
+pub fn f_name(name: &str) -> impl Fn(&Node) -> bool + '_ {
+  move |node: &Node| node.tag_name().name() == name
 }


### PR DESCRIPTION
Providing the `variable` element is not required anymore (it is optional in XSD) for the following elements in the model:
- `inputData`,
- `decision`,
- `businessKnowledgeModel`
- `decisionService`

Now the parser's behaviour (in this case) is fully conformant with the DMN standard since version 1.3.

Done some refactoring also.

closes #56 