### PR TITLE
Enabled arbitrary separator in test files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,7 @@ dependencies = [
  "dsntk-feel",
  "dsntk-feel-evaluator",
  "dsntk-feel-parser",
+ "dsntk-macros",
  "dsntk-model-evaluator",
 ]
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,11 @@ tasks:
     cmds:
       - cmd: ./Coverage-crate.sh dsntk-feel
 
+  cov-evaluator:
+    desc: Runs code coverage for dsntk-evaluator
+    cmds:
+      - cmd: ./Coverage-crate.sh dsntk-evaluator
+
   cov-feel-evaluator:
     desc: Runs code coverage for dsntk-feel-evaluator
     cmds:

--- a/dsntk/src/actions.rs
+++ b/dsntk/src/actions.rs
@@ -645,7 +645,7 @@ fn evaluate_feel_expression(ctx_file_name: &str, feel_file_name: &str) {
 fn test_feel_expression(test_file_name: &str, feel_file_name: &str, summary_only: bool, cm: ColorMode) {
   match fs::read_to_string(feel_file_name) {
     Ok(feel_file_content) => match fs::read_to_string(test_file_name) {
-      Ok(test_file_content) => match dsntk_evaluator::evaluate_test_cases(&test_file_content) {
+      Ok(test_file_content) => match dsntk_evaluator::prepare_test_cases(&test_file_content) {
         Ok(test_cases) => {
           let mut passed = 0_usize;
           let mut failed = 0_usize;
@@ -750,7 +750,7 @@ fn test_decision_table(test_file_name: &str, dectab_file_name: &str, summary_onl
       return;
     }
   };
-  let test_cases = match dsntk_evaluator::evaluate_test_cases(&test_file_content) {
+  let test_cases = match dsntk_evaluator::prepare_test_cases(&test_file_content) {
     Ok(test_cases) => test_cases,
     Err(reason) => {
       eprintln!("evaluating test file failed with reason: {reason}");
@@ -877,7 +877,7 @@ fn test_dmn_model(test_file_name: &str, dmn_file_name: &str, invocable_name: &st
       return;
     }
   };
-  let test_cases = match dsntk_evaluator::evaluate_test_cases(&test_file_content) {
+  let test_cases = match dsntk_evaluator::prepare_test_cases(&test_file_content) {
     Ok(test_cases) => test_cases,
     Err(reason) => {
       eprintln!("evaluating test file failed with reason: {reason}");

--- a/evaluator/Cargo.toml
+++ b/evaluator/Cargo.toml
@@ -15,4 +15,5 @@ dsntk-common = { workspace = true }
 dsntk-feel = { workspace = true }
 dsntk-feel-evaluator = { workspace = true }
 dsntk-feel-parser = { workspace = true }
+dsntk-macros = { workspace = true }
 dsntk-model-evaluator = { workspace = true }

--- a/evaluator/src/errors.rs
+++ b/evaluator/src/errors.rs
@@ -1,0 +1,18 @@
+//! # Evaluator error definitions
+
+use dsntk_common::{DsntkError, ToErrorMessage};
+use dsntk_feel_parser::AstNode;
+
+/// Evaluator error.
+#[derive(ToErrorMessage)]
+struct EvaluatorError(String);
+
+/// Error reported when the expected node is not an expression list.
+pub fn err_expected_expression_list(other: &AstNode) -> DsntkError {
+  EvaluatorError(format!("expected expression list, but found '{other}'")).into()
+}
+
+/// Error reported when the expression list has not exactly 2 elements.
+pub fn err_expected_two_elements_in_expression_list(count: usize) -> DsntkError {
+  EvaluatorError(format!("expression list must have exactly 2 elements, found {count}")).into()
+}

--- a/evaluator/src/lib.rs
+++ b/evaluator/src/lib.rs
@@ -1,5 +1,15 @@
+//! # Evaluator
+//!
+//! FEEL expressions and DMN models evaluator used by components of [**dsntk**][dsntk-url] crate.
+//!
+//! [dsntk-url]: https://crates.io/crates/dsntk
+
+#[macro_use]
+extern crate dsntk_macros;
+
+mod errors;
 mod test_files;
 
 pub use dsntk_feel_evaluator::{evaluate, evaluate_context, evaluate_equals, evaluate_max, evaluate_min, evaluate_sum};
 pub use dsntk_model_evaluator::{build_decision_table_evaluator, ModelEvaluator};
-pub use test_files::evaluate_test_cases;
+pub use test_files::prepare_test_cases;

--- a/evaluator/src/test_files.rs
+++ b/evaluator/src/test_files.rs
@@ -1,18 +1,18 @@
 //! # Implementation of the evaluator for test files
 //!
-//! Test files (textual files containing test cases) are provided for black-box automated testing.
+//! Test files (files containing test cases) are provided for automating tests.
 //!
 //! Test files are used in evaluation tests for:
-//! - `FEEL` expressions (see `tfe` subcommand),
-//! - `DMN` models (see `tmd` subcommand),
-//! - decision tables (see `tdt` subcommand).
+//! - `DMN` models (see `tdm` subcommand),
+//! - decision tables (see `tdt` subcommand),
+//! - `FEEL` expressions (see `tfe` subcommand).
 //!
 //! Single test case has the following structure:
 //! ```text
 //! separator input_data , expected_result
 //! ```
 //! where:
-//! - **separator** is one or more separator characters: `~`, `!`, `@`, `#`, `$`, `%`, `^`, `&`, `|`,
+//! - **separator** is one or more characters at the beginning of the file followed by whitespace,
 //! - **input_data** is a valid `FEEL` context containing input data for a test case,
 //! - **,** is literally the comma character,
 //! - **expected_result** is a valid `FEEL` value that is expected as a result in test case.
@@ -22,6 +22,7 @@
 //! # Example
 //!
 //! An example of a test file may look like this:
+//!
 //! ```text
 //! % { Customer:"Business",   Order:  -3.23 }, 0.10
 //! % { Customer:"Business",   Order:   9.00 }, 0.10
@@ -33,14 +34,15 @@
 //! % { Customer:"Government", Order:  10.00 }, null
 //! ```
 
-use dsntk_common::{DsntkError, Result};
+use crate::errors::{err_expected_expression_list, err_expected_two_elements_in_expression_list};
+use dsntk_common::Result;
 use dsntk_feel::context::FeelContext;
 use dsntk_feel::values::Value;
 use dsntk_feel::FeelScope;
 use dsntk_feel_parser::AstNode;
 
-/// Evaluates test cases loaded from input test file.
-pub fn evaluate_test_cases(input: &str) -> Result<Vec<(FeelContext, Value)>> {
+/// Prepares test cases loaded from the specified input.
+pub fn prepare_test_cases(input: &str) -> Result<Vec<(FeelContext, Value)>> {
   let mut test_cases = vec![];
   if let Some(separator) = detect_separator(input) {
     let scope = FeelScope::default();
@@ -49,13 +51,18 @@ pub fn evaluate_test_cases(input: &str) -> Result<Vec<(FeelContext, Value)>> {
         Ok(ast_node) => match ast_node {
           AstNode::ExpressionList(nodes) => {
             if nodes.len() == 2 {
-              if let Ok(input_data) = dsntk_feel_evaluator::evaluate_context_node(&scope, &nodes[0]) {
-                let expected_result = dsntk_feel_evaluator::evaluate(&scope, &nodes[1]);
-                test_cases.push((input_data, expected_result));
+              match dsntk_feel_evaluator::evaluate_context_node(&scope, &nodes[0]) {
+                Ok(input_data) => {
+                  let expected_result = dsntk_feel_evaluator::evaluate(&scope, &nodes[1]);
+                  test_cases.push((input_data, expected_result));
+                }
+                Err(reason) => return Err(reason),
               }
+            } else {
+              return Err(err_expected_two_elements_in_expression_list(nodes.len()));
             }
           }
-          other => return Err(DsntkError::new("Evaluator", &format!("expected expression list, but found '{other}'"))),
+          other => return Err(err_expected_expression_list(&other)),
         },
         Err(reason) => return Err(reason),
       }
@@ -81,73 +88,47 @@ fn split_test_cases<'a>(input: &'a str, separator: &'a str) -> Vec<&'a str> {
 
 /// Detects the separator used in test file.
 fn detect_separator(input: &str) -> Option<String> {
-  let mut separator = String::with_capacity(80);
-  let mut found = false;
+  enum State {
+    BeforeSeparator,
+    InsideSeparator,
+  }
+  let mut separator = String::new();
+  let mut state = State::BeforeSeparator;
   for ch in input.chars() {
-    if found {
-      if is_separator_character(ch) {
-        separator.push(ch);
-      } else {
-        break;
+    match state {
+      State::BeforeSeparator => {
+        if !ch.is_whitespace() {
+          separator.push(ch);
+          state = State::InsideSeparator;
+        }
       }
-    } else if is_separator_character(ch) {
-      separator.push(ch);
-      found = true;
+      State::InsideSeparator => {
+        if ch.is_whitespace() {
+          break;
+        } else {
+          separator.push(ch);
+        }
+      }
     }
   }
-  if found {
-    Some(separator)
-  } else {
+  if separator.is_empty() {
     None
+  } else {
+    Some(separator)
   }
-}
-
-/// Returns `true` when specified character is a test case separator character.
-///
-/// Valid separator characters are: `~` , `!` , `@` , `#` , `$` , `%` , `^` , `&` , `|`.
-///
-fn is_separator_character(ch: char) -> bool {
-  matches!(ch, '~' | '!' | '@' | '#' | '$' | '%' | '^' | '&' | '|')
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-
-  #[test]
-  fn test_evaluate_empty_test_file() {
-    assert_eq!(0, evaluate_test_cases("").unwrap().len())
-  }
-
-  #[test]
-  fn test_evaluate_test_file() {
-    let input = r#"
-      % { Customer:"Business",   Order:  -3.23 }, 0.10
-      % { Customer:"Business",   Order:   9.00 }, 0.10
-      % { Customer:"Business",   Order:  10.00 }, 0.15
-      % { Customer:"Business",   Order: 120.00 }, 0.15
-      % { Customer:"Private",    Order:  -2.34 }, 0.05
-      % { Customer:"Private",    Order:  10.00 }, 0.05
-      % { Customer:"Private",    Order: 101.00 }, 0.05
-      % { Customer:"Government", Order:  10.00 }, null
-    "#;
-    println!("{:?}", evaluate_test_cases(input));
-    assert_eq!(8, evaluate_test_cases(input).unwrap().len())
-  }
-
-  #[test]
-  #[should_panic(expected = r#"DsntkError("<Evaluator> expected expression list, but found ' Irrelevant\n'"#)]
-  fn test_evaluate_invalid_test_file() {
-    let input = r#"
-      % -
-    "#;
-    evaluate_test_cases(input).unwrap();
-  }
+  use super::detect_separator;
 
   #[test]
   fn test_detect_separator() {
     assert_eq!(None, detect_separator(""));
+    assert_eq!("{", detect_separator("   {  ").unwrap());
+    assert_eq!("{", detect_separator(" \n\n  {  ").unwrap());
     assert_eq!("~", detect_separator("~").unwrap());
+    assert_eq!("~", detect_separator(" \n\n  ~").unwrap());
     assert_eq!("!", detect_separator("!").unwrap());
     assert_eq!("@", detect_separator("@").unwrap());
     assert_eq!("#", detect_separator("#").unwrap());
@@ -157,8 +138,9 @@ mod tests {
     assert_eq!("&", detect_separator("&").unwrap());
     assert_eq!("|", detect_separator("|").unwrap());
     assert_eq!("%%", detect_separator("   %%   ").unwrap());
-    assert_eq!("%%", detect_separator(" \n\n\n \t  %%{   ").unwrap());
+    assert_eq!("%%{", detect_separator(" \n\n\n \t  %%{   ").unwrap());
     assert_eq!("%%", detect_separator(" \n %%\n").unwrap());
     assert_eq!("~!@#$%^&|", detect_separator(" ~!@#$%^&| ").unwrap());
+    assert_eq!("😀", detect_separator(" 😀 ").unwrap());
   }
 }

--- a/evaluator/tests/test_input_files.rs
+++ b/evaluator/tests/test_input_files.rs
@@ -1,0 +1,53 @@
+use dsntk_evaluator::prepare_test_cases;
+
+#[test]
+fn test_empty_input_file() {
+  assert_eq!(0, prepare_test_cases("").unwrap().len())
+}
+
+#[test]
+fn test_valid_input_file() {
+  let input = r#"
+      % { Customer:"Business",   Order:  -3.23 }, 0.10
+      % { Customer:"Business",   Order:   9.00 }, 0.10
+      % { Customer:"Business",   Order:  10.00 }, 0.15
+      % { Customer:"Business",   Order: 120.00 }, 0.15
+      % { Customer:"Private",    Order:  -2.34 }, 0.05
+      % { Customer:"Private",    Order:  10.00 }, 0.05
+      % { Customer:"Private",    Order: 101.00 }, 0.05
+      % { Customer:"Government", Order:  10.00 }, null
+  "#;
+  assert_eq!(8, prepare_test_cases(input).unwrap().len())
+}
+
+#[test]
+fn _0001() {
+  let input = r#"
+      % -
+  "#;
+  assert_eq!(
+    "<EvaluatorError> expected expression list, but found ' Irrelevant\n'",
+    prepare_test_cases(input).unwrap_err().to_string()
+  );
+}
+
+#[test]
+fn _0002() {
+  let input = r#"  % { Customer: "Business"  "#;
+  assert_eq!(r#"<ParserError> syntax error: { Customer: "Business""#, prepare_test_cases(input).unwrap_err().to_string());
+}
+
+#[test]
+fn _0003() {
+  let input = r#"  % { Customer: "Business", Order: 1.12 }, 0.10, 0.20 "#;
+  assert_eq!(
+    "<EvaluatorError> expression list must have exactly 2 elements, found 3",
+    prepare_test_cases(input).unwrap_err().to_string()
+  );
+}
+
+#[test]
+fn _0004() {
+  let input = r#"  % 0.10, 0.20 "#;
+  assert_eq!("<FeelEvaluatorError> expected FEEL context on input", prepare_test_cases(input).unwrap_err().to_string());
+}

--- a/model/src/model.rs
+++ b/model/src/model.rs
@@ -1614,7 +1614,7 @@ pub struct AnnotationEntry {
 }
 
 /// [Dmndi] is a container for the shared [DmnStyle](DmnStyle)s
-/// and all [DmnDiagram](DmnDiagram)s defined in [Definitions].
+/// and all [DmnDiagram]s defined in [Definitions].
 #[derive(Debug, Clone)]
 pub struct Dmndi {
   /// A list of shared [DmnStyle] that can be referenced


### PR DESCRIPTION
Test cases can be now separated using any character(s).
The first non-whitespace text at the beginning of the test file followed by whitespace is a separator.
**NOTE**: Separator string can not appear in any other context in test file, otherwise the test file will probably not compile.